### PR TITLE
Update guildBarSelector to find correct element

### DIFF
--- a/HideSidebar.plugin.js
+++ b/HideSidebar.plugin.js
@@ -1,6 +1,6 @@
 /**
  * @name HideSideBar
- * @version 1.1.3
+ * @version 1.1.4
  * @description Plugin to hide sidebar in discord
  * @author Pieloaf
  * @authorId 439364864763363363
@@ -19,7 +19,7 @@ module.exports = (_ => {
         document.querySelectorAll('[class^="sidebar"]')[0].className
     );
     const guildBarSelector = createSelector(
-        BdApi.findAllModules(m => m.guilds)[1].guilds
+        document.querySelectorAll('[aria-label="Servers sidebar"]')[0].className
     );
     const sidebarBtn = document.createElement('span');
     const btnStyle = `


### PR DESCRIPTION
Recently, BetterDiscord has been throwing this error when trying to load HideSidebar:
```
TypeError: Cannot read properties of undefined (reading 'guilds')
    at eval (betterdiscord://plugins/HideSidebar.plugin.js:24:47)
    at eval (betterdiscord://plugins/HideSidebar.plugin.js:115:3)
    at A.requireAddon (betterdiscord/renderer.js:4:35265)
    at A.loadAddon (betterdiscord/renderer.js:4:7766)
    at A.loadAddon (betterdiscord/renderer.js:4:32937)
    at A.loadAllAddons (betterdiscord/renderer.js:4:10240)
    at A.initialize (betterdiscord/renderer.js:4:4662)
    at A.initialize (betterdiscord/renderer.js:4:32136)
    at Object.startup (betterdiscord/renderer.js:4:357163)
```
`BdApi.findAllModules` is apparently deprecated, so it might be related to that. Regardless, I took a cue from Zer0zzy's fix to sideBarSelector and selected the guild bar through its aria-label attribute. It seems to be working.